### PR TITLE
Refactor Hugging Face deployment workflow to use external script

### DIFF
--- a/.github/scripts/ensure_hf_space.py
+++ b/.github/scripts/ensure_hf_space.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Ensure a Hugging Face Space exists before deployment.
+
+This script mirrors the inline logic from the GitHub Actions workflow but is
+split out so it can be maintained and tested independently.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Optional
+
+
+API_BASE = "https://huggingface.co/api"
+
+
+def require(value: str | None, message: str) -> str:
+    if not value:
+        raise SystemExit(message)
+    return value
+
+
+def build_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def request(method: str, url: str, headers: dict[str, str], payload: Optional[dict] = None) -> bytes:
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req) as resp:
+        return resp.read()
+
+
+def main() -> int:
+    token = require(os.environ.get("HF_TOKEN", ""), "Missing Hugging Face token")
+    slug = require(os.environ.get("SPACE_SLUG", "").strip(), "space_slug input is required")
+    org = os.environ.get("SPACE_ORG", "").strip()
+    sdk = os.environ.get("SPACE_SDK", "").strip() or "gradio"
+    private = os.environ.get("SPACE_PRIVATE", "false").strip().lower() == "true"
+    hardware = os.environ.get("SPACE_HARDWARE", "").strip()
+
+    headers = build_headers(token)
+
+    try:
+        if org:
+            owner = org
+        else:
+            whoami_raw = request("GET", f"{API_BASE}/whoami-v2", headers=headers)
+            whoami = json.loads(whoami_raw)
+            owner = whoami.get("name")
+            if not owner:
+                raise SystemExit("Unable to resolve the current user from the Hugging Face token")
+
+        space_api_url = f"{API_BASE}/spaces/{owner}/{slug}"
+        exists = True
+        try:
+            request("GET", space_api_url, headers=headers)
+        except urllib.error.HTTPError as error:
+            if error.code == 404:
+                exists = False
+            else:
+                raise
+
+        created = False
+        if not exists:
+            payload = {
+                "name": slug,
+                "type": "space",
+                "sdk": sdk,
+                "private": private,
+            }
+            if org:
+                payload["organization"] = org
+            if hardware:
+                payload["hardware"] = hardware
+
+            try:
+                request("POST", f"{API_BASE}/repos/create", headers=headers, payload=payload)
+                created = True
+            except urllib.error.HTTPError as error:
+                if error.code == 409:
+                    created = False
+                else:
+                    raise
+
+        github_output = require(os.environ.get("GITHUB_OUTPUT"), "GITHUB_OUTPUT is not set")
+        with open(github_output, "a", encoding="utf-8") as handle:
+            handle.write(f"space_owner={owner}\n")
+            handle.write(f"space_url=https://huggingface.co/spaces/{owner}/{slug}\n")
+            handle.write(f"space_created={'true' if created else 'false'}\n")
+
+        status = "Created" if created else "Found existing"
+        print(f"{status} Hugging Face Space: https://huggingface.co/spaces/{owner}/{slug}")
+    except urllib.error.HTTPError as error:
+        body = error.read().decode("utf-8", errors="ignore")
+        print(f"::error::Hugging Face API error ({error.code}): {body}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/huggingface-space-deploy.yml
+++ b/.github/workflows/huggingface-space-deploy.yml
@@ -1,0 +1,124 @@
+name: "🚀 Deploy to Hugging Face Space"
+
+on:
+  workflow_dispatch:
+    inputs:
+      space_slug:
+        description: "Space repository slug (e.g. my-awesome-space)"
+        required: true
+      space_org:
+        description: "Organization (leave blank to use the authenticated user)"
+        required: false
+        default: ""
+      space_sdk:
+        description: "Hugging Face Space SDK (gradio, streamlit, static, docker, etc.)"
+        required: true
+        default: "gradio"
+      space_private:
+        description: "Create the Space as private (true/false)"
+        required: true
+        default: "false"
+      space_hardware:
+        description: "Hardware tier (optional, e.g. cpu-basic, t4-small, a10g-large)"
+        required: false
+        default: ""
+      source_dir:
+        description: "Relative path containing the Space assets"
+        required: true
+        default: "."
+      space_branch:
+        description: "Branch to push to on the Space repository"
+        required: true
+        default: "main"
+
+jobs:
+  deploy:
+    name: "Deploy"
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    env:
+      HF_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Ensure Hugging Face Space exists
+        id: ensure_space
+        env:
+          SPACE_SLUG: ${{ inputs.space_slug }}
+          SPACE_ORG: ${{ inputs.space_org }}
+          SPACE_SDK: ${{ inputs.space_sdk }}
+          SPACE_PRIVATE: ${{ inputs.space_private }}
+          SPACE_HARDWARE: ${{ inputs.space_hardware }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${HF_TOKEN}" ]; then
+            echo "::error::The HUGGINGFACE_TOKEN secret is required to deploy." >&2
+            exit 1
+          fi
+
+          python .github/scripts/ensure_hf_space.py
+
+      - name: Prepare Space content
+        env:
+          SOURCE_DIR: ${{ inputs.source_dir }}
+        run: |
+          set -euo pipefail
+          mkdir -p space-dist
+          rsync -av --delete --exclude='.git/' --exclude='.github/' "${SOURCE_DIR}/" space-dist/
+
+      - name: Push to Hugging Face Space
+        env:
+          SPACE_BRANCH: ${{ inputs.space_branch }}
+          SPACE_SLUG: ${{ inputs.space_slug }}
+          SPACE_OWNER: ${{ steps.ensure_space.outputs.space_owner }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${HF_TOKEN}" ]; then
+            echo "::error::The HUGGINGFACE_TOKEN secret is required to deploy." >&2
+            exit 1
+          fi
+
+          cd space-dist
+          git init
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add .
+          if git diff --cached --quiet; then
+            git commit --allow-empty -m "Deploy from GitHub Actions run ${GITHUB_RUN_NUMBER}"
+          else
+            git commit -m "Deploy from GitHub Actions run ${GITHUB_RUN_NUMBER}"
+          fi
+          git branch -M "${SPACE_BRANCH}"
+
+          remote_url="https://huggingface.co/spaces/${SPACE_OWNER}/${SPACE_SLUG}.git"
+          remote_url_auth="https://hf-user:${HF_TOKEN}@huggingface.co/spaces/${SPACE_OWNER}/${SPACE_SLUG}.git"
+          git remote add origin "${remote_url_auth}"
+          git push --force origin "${SPACE_BRANCH}"
+
+          echo "Deployed to ${remote_url}"
+
+      - name: Post summary
+        env:
+          SPACE_URL: ${{ steps.ensure_space.outputs.space_url }}
+          SPACE_CREATED: ${{ steps.ensure_space.outputs.space_created }}
+        run: |
+          {
+            echo "## 🚀 Hugging Face Space Deployment"
+            echo ""
+            echo "- Space: [${SPACE_URL}](${SPACE_URL})"
+            echo "- Newly created this run: ${SPACE_CREATED}"
+            echo "- SDK: \`${{ inputs.space_sdk }}\`"
+            echo "- Source directory: \`${{ inputs.source_dir }}\`"
+            echo "- Branch: \`${{ inputs.space_branch }}\`"
+            echo "- Visibility: \`${{ inputs.space_private }}\`"
+            if [ -n "${{ inputs.space_hardware }}" ]; then
+              echo "- Hardware: \`${{ inputs.space_hardware }}\`"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Summary
- extract the Hugging Face Space provisioning logic into `.github/scripts/ensure_hf_space.py`
- update the workflow to call the standalone Python script instead of an inline heredoc

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d763952e3c832c881b3cf7c80a0584